### PR TITLE
Updated vulnerable packages with latest stable versions

### DIFF
--- a/src/FrontendObligationChecker.IntegrationTests/FrontendObligationChecker.IntegrationTests.csproj
+++ b/src/FrontendObligationChecker.IntegrationTests/FrontendObligationChecker.IntegrationTests.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
         <TargetFramework>net6.0</TargetFramework>
@@ -15,6 +15,8 @@
         <PackageReference Include="MSTest.TestAdapter" Version="2.2.8" />
         <PackageReference Include="MSTest.TestFramework" Version="2.2.8" />
         <PackageReference Include="coverlet.collector" Version="3.1.2" />
+        <PackageReference Include="System.Net.Http" Version="4.3.4" />
+        <PackageReference Include="System.Text.RegularExpressions" Version="4.3.1" />
         <PackageReference Update="StyleCop.Analyzers" Version="1.2.0-beta.435" />
     </ItemGroup>
 

--- a/src/FrontendObligationChecker.UnitTests/FrontendObligationChecker.UnitTests.csproj
+++ b/src/FrontendObligationChecker.UnitTests/FrontendObligationChecker.UnitTests.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
         <TargetFramework>net6.0</TargetFramework>
@@ -17,6 +17,8 @@
         <PackageReference Include="MSTest.TestAdapter" Version="2.2.8" />
         <PackageReference Include="MSTest.TestFramework" Version="2.2.8" />
         <PackageReference Include="coverlet.collector" Version="3.1.2" />
+        <PackageReference Include="System.Net.Http" Version="4.3.4" />
+        <PackageReference Include="System.Text.RegularExpressions" Version="4.3.1" />
         <PackageReference Update="StyleCop.Analyzers" Version="1.2.0-beta.435" />
         <PackageReference Include="coverlet.msbuild" Version="3.2.0">
             <PrivateAssets>all</PrivateAssets>

--- a/src/FrontendObligationChecker/FrontendObligationChecker.csproj
+++ b/src/FrontendObligationChecker/FrontendObligationChecker.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk.Web">
+﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
     <PropertyGroup>
         <TargetFramework>net6.0</TargetFramework>
@@ -42,6 +42,8 @@
       <PackageReference Include="Microsoft.AspNetCore.DataProtection.StackExchangeRedis" Version="7.0.0" />
       <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="8.0.0" />
       <PackageReference Include="Microsoft.Extensions.Caching.StackExchangeRedis" Version="6.0.8" />
+      <PackageReference Include="System.Drawing.Common" Version="8.0.6" />
+      <PackageReference Include="System.Security.Cryptography.Pkcs" Version="8.0.0" />
       <PackageReference Update="StyleCop.Analyzers" Version="1.2.0-beta.435" />
       <PackageReference Include="Microsoft.FeatureManagement" Version="3.1.1" />
       <PackageReference Include="Microsoft.FeatureManagement.AspNetCore" Version="3.1.1" />


### PR DESCRIPTION
Updated the packages with the following versions:

Obligation checker:
<PackageReference Include="System.Drawing.Common" Version="8.0.6" />
<PackageReference Include="System.Security.Cryptography.Pkcs" Version="8.0.0" />

Unit test:
 <PackageReference Include="System.Net.Http" Version="4.3.4" />
 <PackageReference Include="System.Text.RegularExpressions" Version="4.3.1" />

Integration Test:
 <PackageReference Include="System.Net.Http" Version="4.3.4" />
 <PackageReference Include="System.Text.RegularExpressions" Version="4.3.1" />