### PR TITLE
SonarQube cleanup - exclude PageGenerator from duplicate checks  AB#357639

### DIFF
--- a/src/FrontendObligationChecker/FrontendObligationChecker.csproj
+++ b/src/FrontendObligationChecker/FrontendObligationChecker.csproj
@@ -152,7 +152,9 @@
             <Value>Views/**/*.cshtml,**/gulpfile.js,**/Program.cs,**/assets/**,**/ConfigurationExtensions/**,**/Exceptions/**,**/Mapping/**</Value>
         </SonarQubeSetting>
         <SonarQubeSetting Include="sonar.cpd.exclusions">
-            <Value>Views/**/*.cshtml</Value>
+            <Value>
+                Views/**/*.cshtml,Generators/PageGenerator.cs
+            </Value>
         </SonarQubeSetting>
     </ItemGroup>
 


### PR DESCRIPTION
Exclude PageGenerator from duplicate checks, as there is naturally repetition in the class.