### PR TITLE
Feature/521068   obligation checker   add radio button for 'partnership' option

### DIFF
--- a/src/FrontendObligationChecker.IntegrationTests/Journeys/ContentUpdateTicket171354Tests.cs
+++ b/src/FrontendObligationChecker.IntegrationTests/Journeys/ContentUpdateTicket171354Tests.cs
@@ -4,6 +4,7 @@ using FluentAssertions;
 using FrontendObligationChecker.IntegrationTests.Extensions;
 using FrontendObligationChecker.Models.ObligationChecker;
 using FrontendObligationChecker.UnitTests.Helpers;
+
 using YesNo = FrontendObligationChecker.UnitTests.Helpers.YesNo;
 
 namespace FrontendObligationChecker.IntegrationTests.Journeys;
@@ -18,7 +19,7 @@ public class ContentUpdateTicket171354Tests : TestBase
         var page = await PostForm(PagePath.TypeOfOrganisation, form.FormUrlEncodedContent);
         var pageContent = await page.Content.ReadAsStringAsync();
 
-        var selectedAnswer = form.GetTypeOfOrganisation(TypeOfOrganisation.Partnership);
+        var selectedAnswer = PageForm.GetTypeOfOrganisation(TypeOfOrganisation.Partnership);
 
         selectedAnswer.Trim().ToLower().Should().BeEquivalentTo("partnership".Trim().ToLower());
     }

--- a/src/FrontendObligationChecker.IntegrationTests/Journeys/ContentUpdateTicket171354Tests.cs
+++ b/src/FrontendObligationChecker.IntegrationTests/Journeys/ContentUpdateTicket171354Tests.cs
@@ -12,11 +12,23 @@ namespace FrontendObligationChecker.IntegrationTests.Journeys;
 public class ContentUpdateTicket171354Tests : TestBase
 {
     [TestMethod]
+    public async Task TypeOfOrganisation_Partnership_IsSelectedAnswer()
+    {
+        var form = new PageForm(TypeOfOrganisation.Partnership);
+        var page = await PostForm(PagePath.TypeOfOrganisation, form.FormUrlEncodedContent);
+        var pageContent = await page.Content.ReadAsStringAsync();
+
+        var selectedAnswer = form.GetTypeOfOrganisation(TypeOfOrganisation.Partnership);
+
+        selectedAnswer.Trim().ToLower().Should().BeEquivalentTo("partnership".Trim().ToLower());
+    }
+
+    [TestMethod]
     public async Task AnnualTurnover_PageContents_AreUpdated()
     {
         var page = await PostForm(PagePath.TypeOfOrganisation, new PageForm(TypeOfOrganisation.IndividualCompany).FormUrlEncodedContent);
-
         var pageContent = await page.Content.ReadAsStringAsync();
+
         pageContent.Should().Contain("Your answer should include the reported turnover of all relevant subsidiaries in your group that supply (create, import, distribute or sell) packaging.");
     }
 

--- a/src/FrontendObligationChecker.UnitTests/Helpers/PageForm.cs
+++ b/src/FrontendObligationChecker.UnitTests/Helpers/PageForm.cs
@@ -13,6 +13,21 @@ public class PageForm
 
     public FormCollection FormCollection => new(_answers.ToDictionary(o => o.Key, o=> o.Value));
 
+    public string GetTypeOfOrganisation(TypeOfOrganisation organisationType)
+    {
+        string typeOfOrganisation = organisationType switch
+        {
+            TypeOfOrganisation.ParentCompany => "parent",
+            TypeOfOrganisation.Subsidiary => "subsidiary",
+            TypeOfOrganisation.IndividualCompany => "individual",
+            TypeOfOrganisation.Partnership => "partnership",
+            TypeOfOrganisation.NotSet => string.Empty,
+            _ => throw new ArgumentOutOfRangeException(nameof(organisationType), organisationType, null)
+        };
+
+        return typeOfOrganisation;
+    }
+
     public PageForm(TypeOfOrganisation answer)
     {
         string typeOfOrganisation = answer switch
@@ -20,6 +35,7 @@ public class PageForm
             TypeOfOrganisation.ParentCompany => "parent",
             TypeOfOrganisation.Subsidiary => "subsidiary",
             TypeOfOrganisation.IndividualCompany => "individual",
+            TypeOfOrganisation.Partnership => "partnership",
             TypeOfOrganisation.NotSet => string.Empty,
             _ => throw new ArgumentOutOfRangeException(nameof(answer), answer, null)
         };

--- a/src/FrontendObligationChecker.UnitTests/Helpers/PageForm.cs
+++ b/src/FrontendObligationChecker.UnitTests/Helpers/PageForm.cs
@@ -13,7 +13,7 @@ public class PageForm
 
     public FormCollection FormCollection => new(_answers.ToDictionary(o => o.Key, o=> o.Value));
 
-    public string GetTypeOfOrganisation(TypeOfOrganisation organisationType)
+    public static string GetTypeOfOrganisation(TypeOfOrganisation organisationType)
     {
         string typeOfOrganisation = organisationType switch
         {

--- a/src/FrontendObligationChecker.UnitTests/Helpers/VisitedPages.cs
+++ b/src/FrontendObligationChecker.UnitTests/Helpers/VisitedPages.cs
@@ -5,7 +5,8 @@ public enum TypeOfOrganisation
     NotSet = 0,
     ParentCompany,
     Subsidiary,
-    IndividualCompany
+    IndividualCompany,
+    Partnership
 }
 
 public enum AnnualTurnover

--- a/src/FrontendObligationChecker/Generators/PageGenerator.cs
+++ b/src/FrontendObligationChecker/Generators/PageGenerator.cs
@@ -79,6 +79,12 @@ public static class PageGenerator
                             Title = "SingleQuestion.TypeOfOrganisation.QuestionOptionLabel3",
                             Value = "individual"
                         },
+                        new()
+                        {
+                            Next = OptionPath.Secondary,
+                            Title = "SingleQuestion.TypeOfOrganisation.QuestionOptionLabel4",
+                            Value = "partnership"
+                        }
                     },
                     ErrorMessage = "SingleQuestion.TypeOfOrganisation.QuestionError"
                 }

--- a/src/FrontendObligationChecker/Models/ObligationChecker/AssociationType.cs
+++ b/src/FrontendObligationChecker/Models/ObligationChecker/AssociationType.cs
@@ -6,7 +6,8 @@ public enum AssociationType
     Individual = 1,
     Subsidiary = 2,
     Organisation = 3,
-    Parent = 4,
+    Partnership = 4,
+    Parent = 5,
     Associated = 6,
     All = 7
 }

--- a/src/FrontendObligationChecker/Resources/SharedResources.cy.resx
+++ b/src/FrontendObligationChecker/Resources/SharedResources.cy.resx
@@ -245,8 +245,11 @@
     <data name="SingleQuestion.TypeOfOrganisation.QuestionOptionLabel2" xml:space="preserve">
     <value>Is-gwmni</value>
   </data>
-    <data name="SingleQuestion.TypeOfOrganisation.QuestionOptionLabel3" xml:space="preserve">
+  <data name="SingleQuestion.TypeOfOrganisation.QuestionOptionLabel3" xml:space="preserve">
     <value>Cwmni unigol</value>
+  </data>
+  <data name="SingleQuestion.TypeOfOrganisation.QuestionOptionLabel4" xml:space="preserve">
+    <value>Partneriaeth</value>
   </data>
   <data name="SingleQuestion.UnbrandedPackaging.AlternateTitle" xml:space="preserve">
     <value>Rhoi nwyddau i'w gwerthu mewn pecynnau</value>

--- a/src/FrontendObligationChecker/Resources/SharedResources.en.resx
+++ b/src/FrontendObligationChecker/Resources/SharedResources.en.resx
@@ -144,6 +144,9 @@
   <data name="SingleQuestion.TypeOfOrganisation.QuestionOptionLabel3" xml:space="preserve">
     <value>Individual company</value>
   </data>
+  <data name="SingleQuestion.TypeOfOrganisation.QuestionOptionLabel4" xml:space="preserve">
+    <value>Partnership</value>
+  </data>
   <data name="SingleQuestion.AnnualTurnover.QuestionOptionLabel1" xml:space="preserve">
     <value>Under £1 million</value>
   </data>

--- a/src/FrontendObligationChecker/Resources/Views/ObligationChecker/SingleQuestion.cy.resx
+++ b/src/FrontendObligationChecker/Resources/Views/ObligationChecker/SingleQuestion.cy.resx
@@ -387,8 +387,11 @@
     <data name="SingleQuestion.TypeOfOrganisation.QuestionOptionLabel2" xml:space="preserve">
     <value>Is-gwmni</value>
   </data>
-    <data name="SingleQuestion.TypeOfOrganisation.QuestionOptionLabel3" xml:space="preserve">
+  <data name="SingleQuestion.TypeOfOrganisation.QuestionOptionLabel3" xml:space="preserve">
     <value>Cwmni unigol</value>
+  </data>
+  <data name="SingleQuestion.TypeOfOrganisation.QuestionOptionLabel4" xml:space="preserve">
+    <value>Partneriaeth</value>
   </data>
   <data name="SingleQuestion.TypeOfOrganisation.Summary" xml:space="preserve">
     <value>Sut mae'r EPR dros becynwaith yn effeithio ar riant-gwmnïau ac is-gwmnïau</value>

--- a/src/FrontendObligationChecker/Resources/Views/ObligationChecker/SingleQuestion.en.resx
+++ b/src/FrontendObligationChecker/Resources/Views/ObligationChecker/SingleQuestion.en.resx
@@ -132,7 +132,10 @@
   <data name="SingleQuestion.TypeOfOrganisation.QuestionOptionLabel3" xml:space="preserve">
     <value>Individual company</value>
   </data>
-  <data name="SingleQuestion.AnnualTurnover.Title1" xml:space="preserve">
+  <data name="SingleQuestion.TypeOfOrganisation.QuestionOptionLabel4" xml:space="preserve">
+    <value>Partnership</value>
+  </data>
+    <data name="SingleQuestion.AnnualTurnover.Title1" xml:space="preserve">
     <value>What was your group’s last annual turnover?</value>
   </data>
   <data name="SingleQuestion.AnnualTurnover.Title2" xml:space="preserve">

--- a/src/FrontendObligationChecker/Services/PageService/PageService.cs
+++ b/src/FrontendObligationChecker/Services/PageService/PageService.cs
@@ -169,7 +169,7 @@ public class PageService : IPageService
                 "parent" => AssociationType.Parent,
                 "subsidiary" => AssociationType.Subsidiary,
                 "individual" => AssociationType.Individual,
-                _ => page.AssociationType
+                "partnership" => AssociationType.Partnership,
             };
         }
     }
@@ -205,6 +205,7 @@ public class PageService : IPageService
                 "parent" => page.AdditionalDescription,
                 "subsidary" => null,
                 "individual" => null,
+                "partnership" => null,
                 _ => page.AdditionalDescription
             };
         }


### PR DESCRIPTION
New type of organisation option "Partnership" (radio button) has been added in addition to Parent Company, Subsidiary and Individual. Includes updates unit tests and minor Welsh translation to reflect that.