### PR TITLE
Consistency & corrections on public-register page

### DIFF
--- a/release-notes/cliff.toml
+++ b/release-notes/cliff.toml
@@ -113,18 +113,11 @@ protect_breaking_commits = false
 commit_parsers = [
     { message = "^feat", group = "<!-- 0 -->🚀 Features" },
     { message = "^fix", group = "<!-- 1 -->🐛 Bug Fixes" },
+    { message = "^content", group = "<!-- 2 -->📝 Content" },
     { message = "^doc", group = "<!-- 3 -->📚 Documentation" },
     { message = "^perf", group = "<!-- 4 -->⚡ Performance" },
-    { message = "^refactor", group = "<!-- 2 -->🚜 Refactor" },
     { message = "^style", group = "<!-- 5 -->🎨 Styling" },
-    { message = "^test", group = "<!-- 6 -->🧪 Testing" },
-    { message = "^chore\\(release\\): prepare for", skip = true },
-    { message = "^chore\\(deps.*\\)", skip = true },
-    { message = "^chore\\(pr\\)", skip = true },
-    { message = "^chore\\(pull\\)", skip = true },
-    { message = "^chore|^ci", group = "<!-- 7 -->⚙️ Miscellaneous Tasks" },
-    { body = ".*security", group = "<!-- 8 -->🛡️ Security" },
-    { message = "^revert", group = "<!-- 9 -->◀️ Revert" },
+    { body = "^security", group = "<!-- 6 -->🛡️ Security" },
     # Include non-conventional commits only if they have a JIRA ticket
     { message = "eaflood\\.atlassian\\.net/browse/[A-Z]+-[0-9]+", group = "<!-- 99 -->📋 Additional changes" },
     # Skip everything else (no semantic prefix and no ticket)

--- a/src/FrontendObligationChecker/Resources/Views/PublicRegister/Guidance.cy.resx
+++ b/src/FrontendObligationChecker/Resources/Views/PublicRegister/Guidance.cy.resx
@@ -169,10 +169,10 @@
     <value>Oddi wrth:</value>
   </data>
   <data name="Guidance.Heading" xml:space="preserve">
-    <value>Cofrestrau cyhoeddus pecynwaith</value>
+    <value>Cyfrifoldeb cynhyrchydd estynedig ar gyfer pecynnu: cofrestr o gynhyrchwyr pecynnu</value>
   </data>
   <data name="Guidance.LastUpdated" xml:space="preserve">
-    <value>Y diweddariad diwethaf:</value>
+    <value>Y diweddariad diwethaf</value>
   </data>
   <data name="Guidance.NaturalResourcesWalesLink" xml:space="preserve">
     <value>Cyfoeth Naturiol Cymru</value>
@@ -181,13 +181,10 @@
     <value>Asiantaeth Amgylchedd Gogledd Iwerddon</value>
   </data>
   <data name="Guidance.PageTitle" xml:space="preserve">
-    <value>Cofrestrau cyhoeddus pecynwaith</value>
+    <value>Cyfrifoldeb cynhyrchydd estynedig ar gyfer pecynnu: cofrestr o gynhyrchwyr pecynnu</value>
   </data>
   <data name="Guidance.ProducersRegisteredForRpd" xml:space="preserve">
-    <value>Cofrestr gyhoeddus cynhyrchwyr {0}</value>
-  </data>
-  <data name="Guidance.Published" xml:space="preserve">
-    <value>Wedi'i chyhoeddi:</value>
+    <value>Cofrestr cynhyrchwyr {0}</value>
   </data>
   <data name="Guidance.Published2" xml:space="preserve">
     <value>Wedi'i chyhoeddi</value>
@@ -214,10 +211,13 @@
     <value>(ddim ar gael eto)</value>
   </data>
   <data name="Guidance.DisclaimerHeading" xml:space="preserve">
-    <value>Ymwadiad</value>
+    <value>Ynglŷn â'r data</value>
   </data>
   <data name="Guidance.DisclaimerText" xml:space="preserve">
-    <value>Gall rhai meysydd fod yn wag. Un rheswm posibl am hynny yw nad ydyn nhw'n gymwys i'r cynhyrchydd dan sylw.</value>
+    <value>Mae'r rhestr yma yn dangos gwybodaeth heb ei golygu a adroddwyd yn uniongyrchol gan gynhyrchwyr.</value>
+  </data>
+  <data name="Guidance.DisclaimerText2" xml:space="preserve">
+    <value>Gwiriwch gyda'r cynhyrchydd yn uniongyrchol os nad ydych chi'n siŵr am unrhyw beth.</value>
   </data>
   <data name="Guidance.PageTitleOld" xml:space="preserve">
     <value>Cofrestr gyhoeddus ar gyfer y gwasanaeth ‘rhoi gwybod am ddata pecynwaith'</value>

--- a/src/FrontendObligationChecker/Resources/Views/PublicRegister/Guidance.resx
+++ b/src/FrontendObligationChecker/Resources/Views/PublicRegister/Guidance.resx
@@ -148,7 +148,7 @@
     <value>Department for Environment, Food &amp; Rural Affairs</value>
   </data>
     <data name="Guidance.Description" xml:space="preserve">
-    <value>Download a list of producers that are registered on the Report Packaging Data service under the Producer Responsibility Obligations (Packaging and Packaging Waste) Regulations 2024.</value>
+    <value>Download a list of producers registered under the Producer Responsibility Obligations (Packaging and Packaging Waste) Regulations 2024.</value>
   </data>
     <data name="Guidance.Documents" xml:space="preserve">
     <value>Documents</value>
@@ -169,10 +169,10 @@
     <value>From:</value>
   </data>
     <data name="Guidance.Heading" xml:space="preserve">
-    <value>Packaging public registers</value>
+    <value>Extended producer responsibility for packaging: register of packaging producers</value>
   </data>
     <data name="Guidance.LastUpdated" xml:space="preserve">
-    <value>Last updated: </value>
+    <value>Last updated </value>
   </data>
     <data name="Guidance.NaturalResourcesWalesLink" xml:space="preserve">
     <value>Natural Resources Wales</value>
@@ -181,13 +181,10 @@
     <value>Northern Ireland Environment Agency</value>
   </data>
     <data name="Guidance.PageTitle" xml:space="preserve">
-    <value>Packaging public registers</value>
+    <value>Extended producer responsibility for packaging: register of packaging producers</value>
   </data>
     <data name="Guidance.ProducersRegisteredForRpd" xml:space="preserve">
-    <value>{0} Public register of producers</value>
-  </data>
-    <data name="Guidance.Published" xml:space="preserve">
-    <value>Published:</value>
+    <value>{0} register of producers</value>
   </data>
   <data name="Guidance.Published2" xml:space="preserve">
     <value>Published</value>
@@ -214,10 +211,13 @@
     <value>(not yet available)</value>
   </data>
     <data name="Guidance.DisclaimerHeading" xml:space="preserve">
-    <value>Disclaimer</value>
+    <value>About the data</value>
   </data>
     <data name="Guidance.DisclaimerText" xml:space="preserve">
-    <value>Some fields may be blank. This could be because they do not apply to the producer in question.</value>
+    <value>This list shows unedited information reported directly by producers. Some fields may be blank if they do not apply to that producer.</value>
+  </data>
+  <data name="Guidance.DisclaimerText2" xml:space="preserve">
+    <value>Check with the producer directly if you’re unsure about anything.</value>
   </data>
     <data name="Guidance.PageTitleOld" xml:space="preserve">
     <value>Public register for the ‘report packaging data’ service</value>

--- a/src/FrontendObligationChecker/Views/PublicRegister/Guidance.cshtml
+++ b/src/FrontendObligationChecker/Views/PublicRegister/Guidance.cshtml
@@ -41,7 +41,7 @@
                     </a>
                 </p>
                 <p class="govuk-body-s govuk-!-margin-bottom-2">
-                    @Localizer["Guidance.Published"] @Localizer["Guidance.Published2"] @Model.PublishedDate
+                    @Localizer["Guidance.Published2"] @Model.PublishedDate
                 </p>
                 <p class="govuk-body-s">
                     @Localizer["Guidance.LastUpdated"] @Model.LastUpdated
@@ -168,6 +168,7 @@
                 {
                     <h3 id="disclaimer-heading" class="govuk-heading-m">@Localizer["Guidance.DisclaimerHeading"]</h3>
                     <p id="disclaimer-text" class="govuk-hint"> @Localizer["Guidance.DisclaimerText"]</p>
+                    <p id="disclaimer-text-2" class="govuk-hint"> @Localizer["Guidance.DisclaimerText2"]</p>
                 }
 
                 @if (Model.ComplianceSchemeRegisteredFile.FileName is not null)

--- a/src/FrontendObligationChecker/Views/PublicRegister/Guidance.cshtml
+++ b/src/FrontendObligationChecker/Views/PublicRegister/Guidance.cshtml
@@ -300,7 +300,7 @@
 
                 <hr class="govuk-!-margin-top-9 govuk-section-break govuk-section-break--m govuk-section-break--visible">
                 <p class="govuk-body-s govuk-!-margin-bottom-2">
-                    @Localizer["Guidance.Published"] @Localizer["Guidance.Published2"] @Model.PublishedDate
+                    @Localizer["Guidance.Published2"] @Model.PublishedDate
                 </p>
                 <p class="govuk-body-s">
                     @Localizer["Guidance.LastUpdated"] @Model.LastUpdated


### PR DESCRIPTION
# What

Content changes in English and Welsh for current register of producers page. A duplicated word removed from both resx and the cshtml. An extra line added to the 'disclaimer' in both resex and the cshtml. 

# Ticket

https://eaflood.atlassian.net/browse/AMCR-105

# Screenshots

|before|after|
|--|--|
|<img width="896" height="1314" alt="image" src="https://github.com/user-attachments/assets/ec550a9a-9e90-4b01-a219-46ab0e213d0c" />|<img width="1041" height="1494" alt="image" src="https://github.com/user-attachments/assets/0d011804-36af-4e0c-9b11-48c8dc1588e6" />|
|<img width="967" height="1480" alt="image" src="https://github.com/user-attachments/assets/b6f3efc7-0e54-456c-9f75-53adf1dc0854" />|<img width="1041" height="1566" alt="image" src="https://github.com/user-attachments/assets/4ba5fcba-ee4b-42d7-9b4e-1a9038bdb1ef" />|

# Pre-merge checklist

- [x] Release note preview tidy
- [ ] Test evidence attached to ticket


