### PR TITLE
AMCR-88 Remove 1st November trigger

### DIFF
--- a/src/FrontendObligationChecker.UnitTests/Controllers/PublicRegisterControllerTests.cs
+++ b/src/FrontendObligationChecker.UnitTests/Controllers/PublicRegisterControllerTests.cs
@@ -477,8 +477,7 @@
             {
                 PublicRegisterBlobContainerName = "producers-container",
                 PublicRegisterCsoBlobContainerName = "schemes-container",
-                PublishedDate = _publishedDate,
-                PublicRegisterNextYearStartMonthAndDay = $"{DateTime.UtcNow.ToString("MM-dd")}"
+                PublishedDate = _publishedDate
             });
 
             _blobStorageServiceMock

--- a/src/FrontendObligationChecker.UnitTests/Controllers/PublicRegisterLogicTests.cs
+++ b/src/FrontendObligationChecker.UnitTests/Controllers/PublicRegisterLogicTests.cs
@@ -36,7 +36,6 @@ public class PublicRegisterLogicTests
             isPublicRegisterNextYearEnabled: true,
             optionsCurrentYear: null, // only used for manual QA
             optionsPublicRegisterPreviousYearEndMonthAndDay: "02-01",
-            optionsPublicRegisterNextYearStartMonthAndDay: "11-01",
             optionsPublishedDate: new DateTime(2025, 9, 30),
             urlOptionsDefraUrl: "https://defra.example.org",
             urlOptionsBusinessAndEnvironmentUrl: "https://defra.example.org/business",
@@ -100,9 +99,9 @@ public class PublicRegisterLogicTests
     [DataRow(false, "2026-01-02", "2025", "2026", "1 January 2026", "2025/Public_Register_Producers_01_January_2026.csv", "20250378", "2026/Public_Register_Producers_01_January_2026.csv", "20260378")] // 2nd Jan
     [DataRow(false, "2026-01-31", "2025", "2026", "30 January 2026", "2025/Public_Register_Producers_30_January_2026.csv", "20250407", "2026/Public_Register_Producers_30_January_2026.csv", "20260407")]
     [DataRow(false, "2026-02-01", "2025", "2026", "31 January 2026", "2025/Public_Register_Producers_31_January_2026.csv", "20250408", "2026/Public_Register_Producers_31_January_2026.csv", "20260408")] // Configured date for PublicRegister__PublicRegisterPreviousYearEndMonthAndDay "02-01"
-    [DataRow(false, "2026-02-02", "2026", "2027", "1 February 2026", "2026/Public_Register_Producers_01_February_2026.csv", "20260409", null, null)] // after next year's PublicRegister__PublicRegisterNextYearStartMonthAndDay
+    [DataRow(false, "2026-02-02", "2026", "2027", "1 February 2026", "2026/Public_Register_Producers_01_February_2026.csv", "20260409", null, null)] // after previous year cutoff
     [DataRow(false, "2026-10-31", "2026", "2027", "30 October 2026", "2026/Public_Register_Producers_30_October_2026.csv", "20260680", null, null)]
-    [DataRow(false, "2026-11-01", "2026", "2027", "31 October 2026", "2026/Public_Register_Producers_31_October_2026.csv", "20260681", null, null)] // Configured date for PublicRegister__PublicRegisterNextYearStartMonthAndDay "11-01"
+    [DataRow(false, "2026-11-01", "2026", "2027", "31 October 2026", "2026/Public_Register_Producers_31_October_2026.csv", "20260681", null, null)] // Nov 1st (date check removed - feature flag alone controls next year)
     [DataRow(false, "2026-11-02", "2026", "2027", "1 November 2026", "2026/Public_Register_Producers_01_November_2026.csv", "20260682", null, null)]
     // publicRegisterNextYearEnabled on
     [DataRow(true, "2025-12-09", "2025", "2026", "8 December 2025", "2025/Public_Register_Producers_08_December_2025.csv", "20250354", "2026/Public_Register_Producers_08_December_2025.csv", "20260354")] // now
@@ -112,18 +111,18 @@ public class PublicRegisterLogicTests
     [DataRow(true, "2026-01-02", "2025", "2026", "1 January 2026", "2025/Public_Register_Producers_01_January_2026.csv", "20250378", "2026/Public_Register_Producers_01_January_2026.csv", "20260378")] // 2nd Jan
     [DataRow(true, "2026-01-31", "2025", "2026", "30 January 2026", "2025/Public_Register_Producers_30_January_2026.csv", "20250407", "2026/Public_Register_Producers_30_January_2026.csv", "20260407")]
     [DataRow(true, "2026-02-01", "2025", "2026", "31 January 2026", "2025/Public_Register_Producers_31_January_2026.csv", "20250408", "2026/Public_Register_Producers_31_January_2026.csv", "20260408")] // Configured date for PublicRegister__PublicRegisterPreviousYearEndMonthAndDay "02-01"
-    [DataRow(true, "2026-02-02", "2026", "2027", "1 February 2026", "2026/Public_Register_Producers_01_February_2026.csv", "20260409", null, null)] // after next year's PublicRegister__PublicRegisterNextYearStartMonthAndDay
-    [DataRow(true, "2026-10-31", "2026", "2027", "30 October 2026", "2026/Public_Register_Producers_30_October_2026.csv", "20260680", null, null)]
-    [DataRow(true, "2026-11-01", "2026", "2027", "31 October 2026", "2026/Public_Register_Producers_31_October_2026.csv", "20260681", "2027/Public_Register_Producers_31_October_2026.csv", "20270681")] // Configured date for PublicRegister__PublicRegisterNextYearStartMonthAndDay "11-01"
+    [DataRow(true, "2026-02-02", "2026", "2027", "1 February 2026", "2026/Public_Register_Producers_01_February_2026.csv", "20260409", "2027/Public_Register_Producers_01_February_2026.csv", "20270409")] // feature flag alone gates next year
+    [DataRow(true, "2026-10-31", "2026", "2027", "30 October 2026", "2026/Public_Register_Producers_30_October_2026.csv", "20260680", "2027/Public_Register_Producers_30_October_2026.csv", "20270680")]
+    [DataRow(true, "2026-11-01", "2026", "2027", "31 October 2026", "2026/Public_Register_Producers_31_October_2026.csv", "20260681", "2027/Public_Register_Producers_31_October_2026.csv", "20270681")] // Nov 1st (date check removed - feature flag alone controls next year)
     [DataRow(true, "2026-11-02", "2026", "2027", "1 November 2026", "2026/Public_Register_Producers_01_November_2026.csv", "20260682", "2027/Public_Register_Producers_01_November_2026.csv", "20270682")]
     // 2027
     [DataRow(true, "2027-01-01", "2026", "2027", "31 December 2026", "2026/Public_Register_Producers_31_December_2026.csv", "20260742", "2027/Public_Register_Producers_31_December_2026.csv", "20270742")] // new-year's day
     [DataRow(true, "2027-01-02", "2026", "2027", "1 January 2027", "2026/Public_Register_Producers_01_January_2027.csv", "20260743", "2027/Public_Register_Producers_01_January_2027.csv", "20270743")] // 2nd Jan
     [DataRow(true, "2027-01-31", "2026", "2027", "30 January 2027", "2026/Public_Register_Producers_30_January_2027.csv", "20260772", "2027/Public_Register_Producers_30_January_2027.csv", "20270772")]
     [DataRow(true, "2027-02-01", "2026", "2027", "31 January 2027", "2026/Public_Register_Producers_31_January_2027.csv", "20260773", "2027/Public_Register_Producers_31_January_2027.csv", "20270773")] // Configured date for PublicRegister__PublicRegisterPreviousYearEndMonthAndDay "02-01"
-    [DataRow(true, "2027-02-02", "2027", "2028", "1 February 2027", "2027/Public_Register_Producers_01_February_2027.csv", "20270774", null, null)] // after next year's PublicRegister__PublicRegisterNextYearStartMonthAndDay
-    [DataRow(true, "2027-10-31", "2027", "2028", "30 October 2027", "2027/Public_Register_Producers_30_October_2027.csv", "20271045", null, null)]
-    [DataRow(true, "2027-11-01", "2027", "2028", "31 October 2027", "2027/Public_Register_Producers_31_October_2027.csv", "20271046", "2028/Public_Register_Producers_31_October_2027.csv", "20281046")] // Configured date for PublicRegister__PublicRegisterNextYearStartMonthAndDay "11-01"
+    [DataRow(true, "2027-02-02", "2027", "2028", "1 February 2027", "2027/Public_Register_Producers_01_February_2027.csv", "20270774", "2028/Public_Register_Producers_01_February_2027.csv", "20280774")] // feature flag alone gates next year
+    [DataRow(true, "2027-10-31", "2027", "2028", "30 October 2027", "2027/Public_Register_Producers_30_October_2027.csv", "20271045", "2028/Public_Register_Producers_30_October_2027.csv", "20281045")]
+    [DataRow(true, "2027-11-01", "2027", "2028", "31 October 2027", "2027/Public_Register_Producers_31_October_2027.csv", "20271046", "2028/Public_Register_Producers_31_October_2027.csv", "20281046")] // Nov 1st (date check removed - feature flag alone controls next year)
     [DataRow(true, "2027-11-02", "2027", "2028", "1 November 2027", "2027/Public_Register_Producers_01_November_2027.csv", "20271047", "2028/Public_Register_Producers_01_November_2027.csv", "20281047")]
     public async Task TestDateBoundaryLogic(bool publicRegisterNextYearEnabled, string fakeCurrentDate, string expectedCurrentFileDisplayYear, string expectedNextFileDisplayYear, string expectedPageLastUpdated,
         string expectedFile1Filename, string expectedFile1Size,
@@ -220,7 +219,6 @@ public class PublicRegisterLogicTests
             isPublicRegisterNextYearEnabled: publicRegisterNextYearEnabled,
             optionsCurrentYear: null, // This is null in Production, looks like it's only used for testing
             optionsPublicRegisterPreviousYearEndMonthAndDay: "02-01",
-            optionsPublicRegisterNextYearStartMonthAndDay: "11-01",
             optionsPublishedDate: new DateTime(2025, 9, 30, 0, 0, 0, DateTimeKind.Utc),
             urlOptionsDefraUrl: "https://defra.example.org",
             urlOptionsBusinessAndEnvironmentUrl: "https://defra.example.org/business",

--- a/src/FrontendObligationChecker/Controllers/PublicRegisterController.cs
+++ b/src/FrontendObligationChecker/Controllers/PublicRegisterController.cs
@@ -42,7 +42,6 @@
                 isPublicRegisterNextYearEnabled: isPublicRegisterNextYearEnabled,
                 optionsCurrentYear: _options.CurrentYear,
                 optionsPublicRegisterPreviousYearEndMonthAndDay: _options.PublicRegisterPreviousYearEndMonthAndDay,
-                optionsPublicRegisterNextYearStartMonthAndDay: _options.PublicRegisterNextYearStartMonthAndDay,
                 optionsPublishedDate: _options.PublishedDate,
                 urlOptionsDefraUrl: _urlOptions.DefraUrl,
                 urlOptionsBusinessAndEnvironmentUrl: _urlOptions.BusinessAndEnvironmentUrl,
@@ -64,7 +63,6 @@
             bool isPublicRegisterNextYearEnabled,
             string? optionsCurrentYear,
             string? optionsPublicRegisterPreviousYearEndMonthAndDay,
-            string optionsPublicRegisterNextYearStartMonthAndDay,
             DateTime optionsPublishedDate,
             string urlOptionsDefraUrl,
             string urlOptionsBusinessAndEnvironmentUrl,
@@ -93,15 +91,10 @@
                 folderPrefixes.Add(previousYear.ToString());
             }
 
-            // Add next year if feature enabled and today is on or after the configured month and day
+            // Add next year if feature flag is enabled
             if (isPublicRegisterNextYearEnabled)
             {
-                var startMonthDay = optionsPublicRegisterNextYearStartMonthAndDay;
-                if (!string.IsNullOrWhiteSpace(startMonthDay) &&
-                    string.Compare(currentMonthDay, startMonthDay, StringComparison.Ordinal) >= 0)
-                {
-                    folderPrefixes.Add(nextYear.ToString());
-                }
+                folderPrefixes.Add(nextYear.ToString());
             }
 
             // dictionary key is the year, e.g. "2025"

--- a/src/FrontendObligationChecker/Models/Config/PublicRegisterOptions.cs
+++ b/src/FrontendObligationChecker/Models/Config/PublicRegisterOptions.cs
@@ -17,8 +17,6 @@ public class PublicRegisterOptions
 
     public DateTime PublishedDate { get; set; }
 
-    public string PublicRegisterNextYearStartMonthAndDay { get; set; }
-
     public string? PublicRegisterPreviousYearEndMonthAndDay { get; set; }
 
     public string? CurrentYear { get; set; }

--- a/src/FrontendObligationChecker/appsettings.json
+++ b/src/FrontendObligationChecker/appsettings.json
@@ -129,7 +129,6 @@
     "CurrentYear": null,
     "PublicRegisterBlobContainerName": "public-register-producers",
     "PublicRegisterCsoBlobContainerName": "public-register-compliance",
-    "PublicRegisterNextYearStartMonthAndDay": "11-01",
     "PublicRegisterPreviousYearEndMonthAndDay": "02-01"
   },
   "Caching": {

--- a/src/OutsideInTests/Features/PublicRegisterTests.cs
+++ b/src/OutsideInTests/Features/PublicRegisterTests.cs
@@ -17,10 +17,7 @@ public class PublicRegisterTests : IntegrationTestBase
     {
         var result = base.InitializeAsync();
 
-        // These MM-DD thresholds control which year folders are requested.
-        // "11-01" = next year file shown from 1 Nov onwards
         // "02-01" = previous year file shown until 1 Feb
-        ConfigOverrides["PublicRegister:PublicRegisterNextYearStartMonthAndDay"] = "11-01";
         ConfigOverrides["PublicRegister:PublicRegisterPreviousYearEndMonthAndDay"] = "02-01";
         ConfigOverrides["PublicRegister:PublicRegisterBlobContainerName"] = ProducerContainer;
 
@@ -32,7 +29,7 @@ public class PublicRegisterTests : IntegrationTestBase
     {
         // Arrange
         ConfigOverrides["FeatureManagement:PublicRegisterNextYearEnabled"] = "true";
-        ConfigOverrides["PublicRegister:FakeDateTimeUtcNow"] = "2025-12-08"; // after "11-01" threshold
+        ConfigOverrides["PublicRegister:FakeDateTimeUtcNow"] = "2025-12-08";
 
         BlobReader.ContainerBlobs[ProducerContainer] =
         [
@@ -68,7 +65,7 @@ public class PublicRegisterTests : IntegrationTestBase
     {
         // Arrange
         ConfigOverrides["FeatureManagement:PublicRegisterNextYearEnabled"] = "true";
-        ConfigOverrides["PublicRegister:FakeDateTimeUtcNow"] = "2025-12-08"; // after "11-01" threshold
+        ConfigOverrides["PublicRegister:FakeDateTimeUtcNow"] = "2025-12-08";
 
         BlobReader.ContainerBlobs[ProducerContainer] =
         [
@@ -96,7 +93,7 @@ public class PublicRegisterTests : IntegrationTestBase
     {
         // Arrange
         ConfigOverrides["FeatureManagement:PublicRegisterNextYearEnabled"] = "false";
-        ConfigOverrides["PublicRegister:FakeDateTimeUtcNow"] = "2025-12-08"; // after "11-01" threshold
+        ConfigOverrides["PublicRegister:FakeDateTimeUtcNow"] = "2025-12-08";
 
         BlobReader.ContainerBlobs[ProducerContainer] =
         [
@@ -127,11 +124,11 @@ public class PublicRegisterTests : IntegrationTestBase
     }
 
     [Fact]
-    public async Task ShowsOnlyCurrentYearFile_WhenDateBeforeNextYearThreshold()
+    public async Task ShowsCurrentYearAndNextYearFiles_WhenFlagOnRegardlessOfDate()
     {
         // Arrange
         ConfigOverrides["FeatureManagement:PublicRegisterNextYearEnabled"] = "true";
-        ConfigOverrides["PublicRegister:FakeDateTimeUtcNow"] = "2025-06-01"; // before "11-01" threshold
+        ConfigOverrides["PublicRegister:FakeDateTimeUtcNow"] = "2025-06-01"; // before old "11-01" threshold — should still show next year
 
         BlobReader.ContainerBlobs[ProducerContainer] =
         [
@@ -155,9 +152,9 @@ public class PublicRegisterTests : IntegrationTestBase
         // Assert
         using (new AssertionScope())
         {
-            page.DownloadLinks.Should().HaveCount(1, "date is before 11-01 threshold");
+            page.DownloadLinks.Should().HaveCount(2, "feature flag alone controls next year — no date threshold");
             page.DownloadHrefs.Should().Contain(href => href.Contains("fileName=2025"));
-            page.DownloadHrefs.Should().NotContain(href => href.Contains("fileName=2026"));
+            page.DownloadHrefs.Should().Contain(href => href.Contains("fileName=2026"));
         }
     }
 

--- a/src/OutsideInTests/Infrastructure/ObligationCheckerWebApplicationFactory.cs
+++ b/src/OutsideInTests/Infrastructure/ObligationCheckerWebApplicationFactory.cs
@@ -27,6 +27,9 @@ public class ObligationCheckerWebApplicationFactory : WebApplicationFactory<Prog
             ["FeatureManagement:PublicRegisterEnabled"] = "true",
             ["FeatureManagement:LargeProducerRegisterEnabled"] = "true",
 
+            // Use in-memory session to avoid Redis dependency in tests
+            ["UseLocalSession"] = "true",
+
             // Azurite emulator connection string — not a real secret, just satisfies DI wiring.
             ["StorageAccount:ConnectionString"] = "UseDevelopmentStorage=true",
             ["StorageAccount:BlobContainerName"] = "test-container",


### PR DESCRIPTION
As a Regulator

I want to remove the automatic November 1st date trigger for the Public Register

So that I have full manual control over exactly when next year’s data is published via the feature flag alone.

https://eaflood.atlassian.net/browse/AMCR-88