### PR TITLE
AMCR-148 Sync archive page with main register Feb 1st cutover

### DIFF
--- a/src/FrontendObligationChecker.UnitTests/Controllers/LargeProducerRegisterControllerTests.cs
+++ b/src/FrontendObligationChecker.UnitTests/Controllers/LargeProducerRegisterControllerTests.cs
@@ -216,6 +216,49 @@ public class LargeProducerRegisterControllerTests
     }
 
     [TestMethod]
+    [DataRow("2027-01-10", new[] { "2025" })] // 2026 still on main register, archive shows only 2025
+    [DataRow("2027-01-31", new[] { "2025" })] // last day previous year still on main
+    [DataRow("2027-02-01", new[] { "2025", "2026" })] // cutover day — archive picks up 2026
+    [DataRow("2027-02-02", new[] { "2025", "2026" })]
+    [DataRow("2028-01-10", new[] { "2025", "2026" })] // 2027 still on main register
+    [DataRow("2028-02-01", new[] { "2025", "2026", "2027" })] // leap year cutover day
+    [DataRow("2028-02-29", new[] { "2025", "2026", "2027" })] // leap day, after cutover
+    public async Task Get_RegisterOfProducers_AppliesFebruaryCutover_BasedOnFakeDateTimeUtcNow(string fakeUtcNow, string[] expectedPrefixes)
+    {
+        // Arrange
+        _publicRegisterOptions = Options.Create(new PublicRegisterOptions
+        {
+            PublicRegisterBlobContainerName = TestContainerName,
+            CurrentYear = null, // use the (faked) clock
+            PublicRegisterPreviousYearEndMonthAndDay = "02-01",
+            FakeDateTimeUtcNow = fakeUtcNow,
+        });
+
+        _systemUnderTest = new LargeProducerRegisterController(
+            _largeProducerRegisterService.Object,
+            _blobStorageService.Object,
+            _publicRegisterOptions,
+            _logger.Object);
+        _systemUnderTest.ControllerContext.HttpContext = _httpContextMock.Object;
+
+        _largeProducerRegisterService
+            .Setup(x => x.GetLatestAllNationsFileInfoAsync(It.IsAny<string>()))
+            .ReturnsAsync(new List<LargeProducerFileInfoViewModel>());
+
+        List<string>? capturedPrefixes = null;
+        _blobStorageService
+            .Setup(x => x.GetLatestFilePropertiesAsync(TestContainerName, It.IsAny<List<string>>()))
+            .Callback<string, List<string>>((_, prefixes) => capturedPrefixes = prefixes)
+            .ReturnsAsync(new Dictionary<string, PublicRegisterBlobModel>());
+
+        // Act
+        await _systemUnderTest.Get();
+
+        // Assert
+        capturedPrefixes.Should().BeEquivalentTo(expectedPrefixes);
+    }
+
+    [TestMethod]
     public async Task GetFile_WhenReportingYearIsNull_RedirectBackToLargeProducersPage()
     {
         // Act

--- a/src/FrontendObligationChecker.UnitTests/Controllers/PublicRegisterLogicTests.cs
+++ b/src/FrontendObligationChecker.UnitTests/Controllers/PublicRegisterLogicTests.cs
@@ -97,8 +97,8 @@ public class PublicRegisterLogicTests
     [DataRow(false, "2025-12-31", "2025", "2026", "30 December 2025", "2025/Public_Register_Producers_30_December_2025.csv", "20250376", null, null)] // end of year
     [DataRow(false, "2026-01-01", "2025", "2026", "31 December 2025", "2025/Public_Register_Producers_31_December_2025.csv", "20250377", "2026/Public_Register_Producers_31_December_2025.csv", "20260377")] // new-year's day
     [DataRow(false, "2026-01-02", "2025", "2026", "1 January 2026", "2025/Public_Register_Producers_01_January_2026.csv", "20250378", "2026/Public_Register_Producers_01_January_2026.csv", "20260378")] // 2nd Jan
-    [DataRow(false, "2026-01-31", "2025", "2026", "30 January 2026", "2025/Public_Register_Producers_30_January_2026.csv", "20250407", "2026/Public_Register_Producers_30_January_2026.csv", "20260407")]
-    [DataRow(false, "2026-02-01", "2025", "2026", "31 January 2026", "2025/Public_Register_Producers_31_January_2026.csv", "20250408", "2026/Public_Register_Producers_31_January_2026.csv", "20260408")] // Configured date for PublicRegister__PublicRegisterPreviousYearEndMonthAndDay "02-01"
+    [DataRow(false, "2026-01-31", "2025", "2026", "30 January 2026", "2025/Public_Register_Producers_30_January_2026.csv", "20250407", "2026/Public_Register_Producers_30_January_2026.csv", "20260407")] // last day previous year is shown alongside current year
+    [DataRow(false, "2026-02-01", "2026", "2027", "31 January 2026", "2026/Public_Register_Producers_31_January_2026.csv", "20260408", null, null)] // Configured date for PublicRegister__PublicRegisterPreviousYearEndMonthAndDay "02-01" — cutover day, previous year dropped
     [DataRow(false, "2026-02-02", "2026", "2027", "1 February 2026", "2026/Public_Register_Producers_01_February_2026.csv", "20260409", null, null)] // after previous year cutoff
     [DataRow(false, "2026-10-31", "2026", "2027", "30 October 2026", "2026/Public_Register_Producers_30_October_2026.csv", "20260680", null, null)]
     [DataRow(false, "2026-11-01", "2026", "2027", "31 October 2026", "2026/Public_Register_Producers_31_October_2026.csv", "20260681", null, null)] // Nov 1st (date check removed - feature flag alone controls next year)
@@ -109,8 +109,8 @@ public class PublicRegisterLogicTests
     // 2026
     [DataRow(true, "2026-01-01", "2025", "2026", "31 December 2025", "2025/Public_Register_Producers_31_December_2025.csv", "20250377", "2026/Public_Register_Producers_31_December_2025.csv", "20260377")] // new-year's day
     [DataRow(true, "2026-01-02", "2025", "2026", "1 January 2026", "2025/Public_Register_Producers_01_January_2026.csv", "20250378", "2026/Public_Register_Producers_01_January_2026.csv", "20260378")] // 2nd Jan
-    [DataRow(true, "2026-01-31", "2025", "2026", "30 January 2026", "2025/Public_Register_Producers_30_January_2026.csv", "20250407", "2026/Public_Register_Producers_30_January_2026.csv", "20260407")]
-    [DataRow(true, "2026-02-01", "2025", "2026", "31 January 2026", "2025/Public_Register_Producers_31_January_2026.csv", "20250408", "2026/Public_Register_Producers_31_January_2026.csv", "20260408")] // Configured date for PublicRegister__PublicRegisterPreviousYearEndMonthAndDay "02-01"
+    [DataRow(true, "2026-01-31", "2025", "2026", "30 January 2026", "2025/Public_Register_Producers_30_January_2026.csv", "20250407", "2026/Public_Register_Producers_30_January_2026.csv", "20260407")] // last day previous year is shown alongside current year
+    [DataRow(true, "2026-02-01", "2026", "2027", "31 January 2026", "2026/Public_Register_Producers_31_January_2026.csv", "20260408", "2027/Public_Register_Producers_31_January_2026.csv", "20270408")] // Configured date for PublicRegister__PublicRegisterPreviousYearEndMonthAndDay "02-01" — cutover day, previous year dropped
     [DataRow(true, "2026-02-02", "2026", "2027", "1 February 2026", "2026/Public_Register_Producers_01_February_2026.csv", "20260409", "2027/Public_Register_Producers_01_February_2026.csv", "20270409")] // feature flag alone gates next year
     [DataRow(true, "2026-10-31", "2026", "2027", "30 October 2026", "2026/Public_Register_Producers_30_October_2026.csv", "20260680", "2027/Public_Register_Producers_30_October_2026.csv", "20270680")]
     [DataRow(true, "2026-11-01", "2026", "2027", "31 October 2026", "2026/Public_Register_Producers_31_October_2026.csv", "20260681", "2027/Public_Register_Producers_31_October_2026.csv", "20270681")] // Nov 1st (date check removed - feature flag alone controls next year)
@@ -118,12 +118,16 @@ public class PublicRegisterLogicTests
     // 2027
     [DataRow(true, "2027-01-01", "2026", "2027", "31 December 2026", "2026/Public_Register_Producers_31_December_2026.csv", "20260742", "2027/Public_Register_Producers_31_December_2026.csv", "20270742")] // new-year's day
     [DataRow(true, "2027-01-02", "2026", "2027", "1 January 2027", "2026/Public_Register_Producers_01_January_2027.csv", "20260743", "2027/Public_Register_Producers_01_January_2027.csv", "20270743")] // 2nd Jan
-    [DataRow(true, "2027-01-31", "2026", "2027", "30 January 2027", "2026/Public_Register_Producers_30_January_2027.csv", "20260772", "2027/Public_Register_Producers_30_January_2027.csv", "20270772")]
-    [DataRow(true, "2027-02-01", "2026", "2027", "31 January 2027", "2026/Public_Register_Producers_31_January_2027.csv", "20260773", "2027/Public_Register_Producers_31_January_2027.csv", "20270773")] // Configured date for PublicRegister__PublicRegisterPreviousYearEndMonthAndDay "02-01"
+    [DataRow(true, "2027-01-31", "2026", "2027", "30 January 2027", "2026/Public_Register_Producers_30_January_2027.csv", "20260772", "2027/Public_Register_Producers_30_January_2027.csv", "20270772")] // last day previous year is shown alongside current year
+    [DataRow(true, "2027-02-01", "2027", "2028", "31 January 2027", "2027/Public_Register_Producers_31_January_2027.csv", "20270773", "2028/Public_Register_Producers_31_January_2027.csv", "20280773")] // Configured date for PublicRegister__PublicRegisterPreviousYearEndMonthAndDay "02-01" — cutover day, previous year dropped
     [DataRow(true, "2027-02-02", "2027", "2028", "1 February 2027", "2027/Public_Register_Producers_01_February_2027.csv", "20270774", "2028/Public_Register_Producers_01_February_2027.csv", "20280774")] // feature flag alone gates next year
     [DataRow(true, "2027-10-31", "2027", "2028", "30 October 2027", "2027/Public_Register_Producers_30_October_2027.csv", "20271045", "2028/Public_Register_Producers_30_October_2027.csv", "20281045")]
     [DataRow(true, "2027-11-01", "2027", "2028", "31 October 2027", "2027/Public_Register_Producers_31_October_2027.csv", "20271046", "2028/Public_Register_Producers_31_October_2027.csv", "20281046")] // Nov 1st (date check removed - feature flag alone controls next year)
     [DataRow(true, "2027-11-02", "2027", "2028", "1 November 2027", "2027/Public_Register_Producers_01_November_2027.csv", "20271047", "2028/Public_Register_Producers_01_November_2027.csv", "20281047")]
+    // 2028 — leap year cutover sanity checks
+    [DataRow(true, "2028-01-31", "2027", "2028", "30 January 2028", "2027/Public_Register_Producers_30_January_2028.csv", "20271137", "2028/Public_Register_Producers_30_January_2028.csv", "20281137")] // last day previous year shown
+    [DataRow(true, "2028-02-01", "2028", "2029", "31 January 2028", "2028/Public_Register_Producers_31_January_2028.csv", "20281138", null, null)] // leap year cutover day — previous year dropped (2029 folder has no data so next year file is null)
+    [DataRow(true, "2028-02-29", "2028", "2029", "28 February 2028", "2028/Public_Register_Producers_28_February_2028.csv", "20281166", null, null)] // leap day — still after cutover, no overlap with archive
     public async Task TestDateBoundaryLogic(bool publicRegisterNextYearEnabled, string fakeCurrentDate, string expectedCurrentFileDisplayYear, string expectedNextFileDisplayYear, string expectedPageLastUpdated,
         string expectedFile1Filename, string expectedFile1Size,
         string? expectedFile2Filename, string expectedFile2Size)

--- a/src/FrontendObligationChecker.UnitTests/Services/PublicRegister/PublicRegisterCutoverHelperTests.cs
+++ b/src/FrontendObligationChecker.UnitTests/Services/PublicRegister/PublicRegisterCutoverHelperTests.cs
@@ -1,0 +1,68 @@
+namespace FrontendObligationChecker.UnitTests.Services.PublicRegister;
+
+using System.Globalization;
+using FluentAssertions;
+using FrontendObligationChecker.Models.Config;
+using FrontendObligationChecker.Services.PublicRegister;
+
+[TestClass]
+public class PublicRegisterCutoverHelperTests
+{
+    [TestMethod]
+    // Cutover string "02-01" — strict less-than semantics
+    [DataRow("2027-01-01", "02-01", true)] // start of year — previous year still on main
+    [DataRow("2027-01-10", "02-01", true)]
+    [DataRow("2027-01-31", "02-01", true)] // last day previous year is shown on main
+    [DataRow("2027-02-01", "02-01", false)] // cutover day — main drops, archive picks up
+    [DataRow("2027-02-02", "02-01", false)]
+    [DataRow("2027-03-01", "02-01", false)]
+    [DataRow("2027-12-31", "02-01", false)]
+    // Leap year — cutover unaffected by Feb 29
+    [DataRow("2028-01-31", "02-01", true)]
+    [DataRow("2028-02-01", "02-01", false)]
+    [DataRow("2028-02-29", "02-01", false)]
+    public void IsPreviousYearStillOnMainRegister_ReturnsExpected(string utcNowString, string endMonthDay, bool expected)
+    {
+        var utcNow = DateTime.ParseExact(utcNowString, "yyyy-MM-dd", CultureInfo.InvariantCulture);
+
+        var actual = PublicRegisterCutoverHelper.IsPreviousYearStillOnMainRegister(utcNow, endMonthDay);
+
+        actual.Should().Be(expected);
+    }
+
+    [TestMethod]
+    [DataRow(null)]
+    [DataRow("")]
+    [DataRow("   ")]
+    public void IsPreviousYearStillOnMainRegister_ReturnsFalse_WhenEndMonthDayMissing(string? endMonthDay)
+    {
+        var actual = PublicRegisterCutoverHelper.IsPreviousYearStillOnMainRegister(
+            new DateTime(2027, 1, 10), endMonthDay);
+
+        actual.Should().BeFalse();
+    }
+
+    [TestMethod]
+    public void GetEffectiveUtcNow_ReturnsRealUtcNow_WhenOverrideNotSet()
+    {
+        var options = new PublicRegisterOptions { FakeDateTimeUtcNow = null };
+
+        var before = DateTime.UtcNow;
+        var actual = PublicRegisterCutoverHelper.GetEffectiveUtcNow(options);
+        var after = DateTime.UtcNow;
+
+        actual.Should().BeOnOrAfter(before).And.BeOnOrBefore(after);
+    }
+
+    [TestMethod]
+    [DataRow("2027-01-10")]
+    [DataRow("2028-02-29")]
+    public void GetEffectiveUtcNow_ReturnsParsedOverride_WhenSet(string fakeDate)
+    {
+        var options = new PublicRegisterOptions { FakeDateTimeUtcNow = fakeDate };
+
+        var actual = PublicRegisterCutoverHelper.GetEffectiveUtcNow(options);
+
+        actual.Should().Be(DateTime.ParseExact(fakeDate, "yyyy-MM-dd", CultureInfo.InvariantCulture));
+    }
+}

--- a/src/FrontendObligationChecker/Controllers/LargeProducerRegisterController.cs
+++ b/src/FrontendObligationChecker/Controllers/LargeProducerRegisterController.cs
@@ -77,12 +77,24 @@ public class LargeProducerRegisterController : Controller
     {
         var containerName = _publicRegisterOptions.PublicRegisterBlobContainerName;
 
+        var utcNow = PublicRegisterCutoverHelper.GetEffectiveUtcNow(_publicRegisterOptions);
+
         int currentYear = string.IsNullOrWhiteSpace(_publicRegisterOptions.CurrentYear)
-            ? DateTime.UtcNow.Year
+            ? utcNow.Year
             : int.Parse(_publicRegisterOptions.CurrentYear);
 
+        // While the previous year is still being shown on the main public register, exclude
+        // it from the archive so the same year is never displayed on both pages at once.
+        int archiveEndYearExclusive = currentYear;
+        if (PublicRegisterCutoverHelper.IsPreviousYearStillOnMainRegister(
+                utcNow, _publicRegisterOptions.PublicRegisterPreviousYearEndMonthAndDay))
+        {
+            archiveEndYearExclusive = currentYear - 1;
+        }
+
+        var count = Math.Max(0, archiveEndYearExclusive - RegisterOfProducersStartYear);
         var folderPrefixes = Enumerable
-            .Range(RegisterOfProducersStartYear, currentYear - RegisterOfProducersStartYear)
+            .Range(RegisterOfProducersStartYear, count)
             .Select(y => y.ToString())
             .ToList();
 

--- a/src/FrontendObligationChecker/Controllers/PublicRegisterController.cs
+++ b/src/FrontendObligationChecker/Controllers/PublicRegisterController.cs
@@ -47,9 +47,7 @@
                 urlOptionsBusinessAndEnvironmentUrl: _urlOptions.BusinessAndEnvironmentUrl,
                 defraHelplineEmail: _emailAddressOptions.DefraHelpline,
                 urlOptionsPublicRegisterScottishProtectionAgency: _urlOptions.PublicRegisterScottishProtectionAgency,
-                getUtcNow: () => string.IsNullOrWhiteSpace(_options.FakeDateTimeUtcNow)
-                    ? DateTime.UtcNow
-                    : DateTime.ParseExact(_options.FakeDateTimeUtcNow, "yyyy-MM-dd", System.Globalization.CultureInfo.InvariantCulture),
+                getUtcNow: () => PublicRegisterCutoverHelper.GetEffectiveUtcNow(_options),
                 blobStorageService: blobStorageService,
                 optionsPublicRegisterBlobContainerName: _options.PublicRegisterBlobContainerName,
                 optionsPublicRegisterCsoBlobContainerName: _options.PublicRegisterCsoBlobContainerName);
@@ -81,12 +79,11 @@
             int nextYear = currentYear + 1;
             var folderPrefixes = new List<string> { currentYear.ToString() };
 
-            var endMonthDay = optionsPublicRegisterPreviousYearEndMonthAndDay;
-            var currentMonthDay = getUtcNow().ToString("MM-dd");
-
-            // Add previous year if today is on or before the configured month and day
-            if (!string.IsNullOrWhiteSpace(endMonthDay) &&
-                 string.Compare(currentMonthDay, endMonthDay, StringComparison.Ordinal) <= 0)
+            // Add previous year if today is strictly before the configured cutover month and day.
+            // Strict less-than ensures the main register drops the previous year on the cutover
+            // date itself, at the same instant the archive page picks it up (no overlap).
+            if (PublicRegisterCutoverHelper.IsPreviousYearStillOnMainRegister(
+                    getUtcNow(), optionsPublicRegisterPreviousYearEndMonthAndDay))
             {
                 folderPrefixes.Add(previousYear.ToString());
             }

--- a/src/FrontendObligationChecker/Services/PublicRegister/PublicRegisterCutoverHelper.cs
+++ b/src/FrontendObligationChecker/Services/PublicRegister/PublicRegisterCutoverHelper.cs
@@ -1,0 +1,36 @@
+namespace FrontendObligationChecker.Services.PublicRegister;
+
+using System.Globalization;
+using FrontendObligationChecker.Models.Config;
+
+public static class PublicRegisterCutoverHelper
+{
+    /// <summary>
+    /// Returns the effective "now" for public-register pages, honouring the
+    /// <see cref="PublicRegisterOptions.FakeDateTimeUtcNow"/> QA override when set.
+    /// </summary>
+    public static DateTime GetEffectiveUtcNow(PublicRegisterOptions options)
+    {
+        return string.IsNullOrWhiteSpace(options.FakeDateTimeUtcNow)
+            ? DateTime.UtcNow
+            : DateTime.ParseExact(options.FakeDateTimeUtcNow, "yyyy-MM-dd", CultureInfo.InvariantCulture);
+    }
+
+    /// <summary>
+    /// Returns true if the previous calendar year is still being shown on the main
+    /// public register as of <paramref name="utcNow"/>. Strict less-than comparison
+    /// against <paramref name="endMonthDay"/> ("MM-dd") so that on the cutover date
+    /// itself the previous year is dropped from the main register and picked up by
+    /// the archive page (no overlap between the two pages).
+    /// </summary>
+    public static bool IsPreviousYearStillOnMainRegister(DateTime utcNow, string? endMonthDay)
+    {
+        if (string.IsNullOrWhiteSpace(endMonthDay))
+        {
+            return false;
+        }
+
+        var currentMonthDay = utcNow.ToString("MM-dd", CultureInfo.InvariantCulture);
+        return string.Compare(currentMonthDay, endMonthDay, StringComparison.Ordinal) < 0;
+    }
+}

--- a/src/FrontendObligationChecker/appsettings.json
+++ b/src/FrontendObligationChecker/appsettings.json
@@ -127,6 +127,7 @@
   "PublicRegister": {
     "PublishedDate": "2025-12-06",
     "CurrentYear": null,
+    "FakeDateTimeUtcNow": null,
     "PublicRegisterBlobContainerName": "public-register-producers",
     "PublicRegisterCsoBlobContainerName": "public-register-compliance",
     "PublicRegisterPreviousYearEndMonthAndDay": "02-01"

--- a/src/OutsideInTests/Features/LargeProducerRegisterTests.cs
+++ b/src/OutsideInTests/Features/LargeProducerRegisterTests.cs
@@ -11,24 +11,37 @@ using FrontendObligationChecker.Models.BlobReader;
 [Collection(SequentialCollection.Sequential)]
 public class LargeProducerRegisterTests : IntegrationTestBase
 {
+    private const string ProducerContainer = "public-register-producers";
+
+    public override Task InitializeAsync()
+    {
+        var result = base.InitializeAsync();
+
+        ConfigOverrides["PublicRegister:PublicRegisterPreviousYearEndMonthAndDay"] = "02-01";
+        ConfigOverrides["PublicRegister:PublicRegisterBlobContainerName"] = ProducerContainer;
+
+        return result;
+    }
+
     [Fact]
     public async Task LargeProducers_ShowsPageWithFileList()
     {
         // Arrange - blobs in two year directories with the "large_producers" prefix
-        // that LargeProducerRegisterService looks for via IBlobReader
+        // that LargeProducerRegisterService looks for via IBlobReader.
+        // Only years < 2025 appear in the "List of Large Producers" section.
         BlobReader.Blobs =
         [
-            new BlobModel
-            {
-                Name = "2025/large_producers_20250615.csv",
-                ContentLength = 1258291,
-                CreatedOn = new DateTime(2025, 6, 15)
-            },
             new BlobModel
             {
                 Name = "2024/large_producers_20241201.csv",
                 ContentLength = 921600,
                 CreatedOn = new DateTime(2024, 12, 1)
+            },
+            new BlobModel
+            {
+                Name = "2023/large_producers_20231201.csv",
+                ContentLength = 800000,
+                CreatedOn = new DateTime(2023, 12, 1)
             }
         ];
 
@@ -40,9 +53,8 @@ public class LargeProducerRegisterTests : IntegrationTestBase
         {
             page.Heading.Should().NotBeNullOrEmpty();
             page.Files.Should().HaveCount(2);
-            page.Files[0].Year.Should().Be("2025");
-            page.Files[0].Href.Should().Contain("reportingYear=2025");
-            page.Files[1].Year.Should().Be("2024");
+            page.Files[0].Href.Should().Contain("reportingYear=2024");
+            page.Files[1].Href.Should().Contain("reportingYear=2023");
         }
     }
 
@@ -59,6 +71,117 @@ public class LargeProducerRegisterTests : IntegrationTestBase
         {
             page.Heading.Should().NotBeNullOrEmpty();
             page.Files.Should().BeEmpty();
+        }
+    }
+
+    [Fact]
+    public async Task RegisterOfProducers_ExcludesPreviousYear_BeforeCutover()
+    {
+        // Arrange — January 10 2027: previous year (2026) is still on the main register,
+        // so the archive should show only 2025.
+        ConfigOverrides["PublicRegister:FakeDateTimeUtcNow"] = "2027-01-10";
+
+        BlobReader.ContainerBlobs[ProducerContainer] =
+        [
+            new BlobModel
+            {
+                Name = "2025/Public_Register_Producers_01_December_2025.csv",
+                ContentLength = 100000,
+                LastModified = new DateTime(2025, 12, 1)
+            },
+            new BlobModel
+            {
+                Name = "2026/Public_Register_Producers_01_December_2026.csv",
+                ContentLength = 200000,
+                LastModified = new DateTime(2026, 12, 1)
+            }
+        ];
+
+        // Act
+        var page = await GetAsPageModel<LargeProducerRegisterPageModel>("/large-producers");
+
+        // Assert — only 2025 should appear, not 2026
+        using (new AssertionScope())
+        {
+            page.RegisterOfProducersLinks.Should().HaveCount(1);
+            page.RegisterOfProducersLinks[0].Href.Should().Contain("fileName=2025");
+        }
+    }
+
+    [Fact]
+    public async Task RegisterOfProducers_IncludesPreviousYear_OnCutoverDay()
+    {
+        // Arrange — February 1 2027: cutover day. Previous year (2026) is dropped from
+        // the main register and should now appear in the archive.
+        ConfigOverrides["PublicRegister:FakeDateTimeUtcNow"] = "2027-02-01";
+
+        BlobReader.ContainerBlobs[ProducerContainer] =
+        [
+            new BlobModel
+            {
+                Name = "2025/Public_Register_Producers_01_December_2025.csv",
+                ContentLength = 100000,
+                LastModified = new DateTime(2025, 12, 1)
+            },
+            new BlobModel
+            {
+                Name = "2026/Public_Register_Producers_01_December_2026.csv",
+                ContentLength = 200000,
+                LastModified = new DateTime(2026, 12, 1)
+            }
+        ];
+
+        // Act
+        var page = await GetAsPageModel<LargeProducerRegisterPageModel>("/large-producers");
+
+        // Assert — both 2025 and 2026 should appear (ordered descending)
+        using (new AssertionScope())
+        {
+            page.RegisterOfProducersLinks.Should().HaveCount(2);
+            page.RegisterOfProducersLinks[0].Href.Should().Contain("fileName=2026");
+            page.RegisterOfProducersLinks[1].Href.Should().Contain("fileName=2025");
+        }
+    }
+
+    [Fact]
+    public async Task RegisterOfProducers_LeapYear_CutoverWorksCorrectly()
+    {
+        // Arrange — February 1 2028 (leap year): cutover day, previous year (2027) drops
+        // from main register and appears in archive.
+        ConfigOverrides["PublicRegister:FakeDateTimeUtcNow"] = "2028-02-01";
+
+        BlobReader.ContainerBlobs[ProducerContainer] =
+        [
+            new BlobModel
+            {
+                Name = "2025/Public_Register_Producers_01_December_2025.csv",
+                ContentLength = 100000,
+                LastModified = new DateTime(2025, 12, 1)
+            },
+            new BlobModel
+            {
+                Name = "2026/Public_Register_Producers_01_December_2026.csv",
+                ContentLength = 200000,
+                LastModified = new DateTime(2026, 12, 1)
+            },
+            new BlobModel
+            {
+                Name = "2027/Public_Register_Producers_01_December_2027.csv",
+                ContentLength = 300000,
+                LastModified = new DateTime(2027, 12, 1)
+            }
+        ];
+
+        // Act
+        var page = await GetAsPageModel<LargeProducerRegisterPageModel>("/large-producers");
+
+        // Assert — 2025, 2026, and 2027 should all appear
+        using (new AssertionScope())
+        {
+            page.RegisterOfProducersLinks.Should().HaveCount(3);
+            page.RegisterOfProducersLinks[0].Href.Should().Contain("fileName=2027");
+            page.RegisterOfProducersLinks[1].Href.Should().Contain("fileName=2026");
+            page.RegisterOfProducersLinks[2].Href.Should().Contain("fileName=2025");
         }
     }
 }

--- a/src/OutsideInTests/Features/LargeProducerRegisterTests.cs
+++ b/src/OutsideInTests/Features/LargeProducerRegisterTests.cs
@@ -144,7 +144,7 @@ public class LargeProducerRegisterTests : IntegrationTestBase
     }
 
     [Fact]
-    public async Task RegisterOfProducers_LeapYear_CutoverWorksCorrectly()
+    public async Task RegisterOfProducers_IncludesPreviousYear_OnLeapYearCutoverDay()
     {
         // Arrange — February 1 2028 (leap year): cutover day, previous year (2027) drops
         // from main register and appears in archive.

--- a/src/OutsideInTests/PageModels/LargeProducerRegisterPageModel.cs
+++ b/src/OutsideInTests/PageModels/LargeProducerRegisterPageModel.cs
@@ -4,18 +4,35 @@ public class LargeProducerRegisterPageModel : PageModelBase, IPageModelFactory<L
 {
     public string? Heading => _document.QuerySelector("h1.govuk-heading-l")?.TextContent.Trim();
 
+    /// <summary>
+    /// Links in the "List of large producers" section (pre-2025 reports).
+    /// These are plain anchor tags whose href points to /large-producers/report.
+    /// </summary>
     public IReadOnlyList<FileEntry> Files =>
-        _document.QuerySelectorAll("ul.govuk-list > li")
-            .Where(li => li.QuerySelector("h3.govuk-heading-s") != null)
-            .Select(li => new FileEntry(
-                li.QuerySelector("h3.govuk-heading-s")?.TextContent.Trim() ?? "",
-                li.QuerySelector("a.govuk-link")?.GetAttribute("href") ?? "",
-                li.QuerySelector("a.govuk-link")?.TextContent.Trim() ?? ""))
+        _document.QuerySelectorAll("a.govuk-link")
+            .Where(a => (a.GetAttribute("href") ?? "").Contains("/large-producers/report"))
+            .Select(a => new FileEntry(
+                a.GetAttribute("href") ?? "",
+                a.TextContent.Trim()))
+            .ToList();
+
+    /// <summary>
+    /// Links in the "Register of producers" section (archive page).
+    /// These are plain anchor tags whose href points to /public-register/report.
+    /// </summary>
+    public IReadOnlyList<RegisterOfProducersEntry> RegisterOfProducersLinks =>
+        _document.QuerySelectorAll("a.govuk-link")
+            .Where(a => (a.GetAttribute("href") ?? "").Contains("/public-register/report"))
+            .Select(a => new RegisterOfProducersEntry(
+                a.GetAttribute("href") ?? "",
+                a.TextContent.Trim()))
             .ToList();
 
     private LargeProducerRegisterPageModel(string html) : base(html) { }
 
     public static LargeProducerRegisterPageModel FromContent(string html) => new(html);
 
-    public record FileEntry(string Year, string Href, string LinkText);
+    public record FileEntry(string Href, string LinkText);
+
+    public record RegisterOfProducersEntry(string Href, string LinkText);
 }


### PR DESCRIPTION
The archive page (Register of Producers on /large-producers) was showing the previous year's register from January 1st, while the main public register still displayed it until February. This caused both pages to show the same year during January.

- Extract shared cutover logic into PublicRegisterCutoverHelper
- Change main register comparison from <= to < so it drops the previous year on Feb 1st (was Feb 2nd)
- Archive page now excludes the previous year while it is still on the main register, guaranteeing zero overlap
- Wire FakeDateTimeUtcNow into archive controller for QA time-travel
- Add unit tests for helper, update characterisation tests, add parameterised cutover tests including leap-year coverage

Covers the acceptance criteria on [AMCR-148](https://eaflood.atlassian.net/browse/AMCR-148).

[AMCR-148]: https://eaflood.atlassian.net/browse/AMCR-148?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ